### PR TITLE
MetaData Plugin: Allow Best Image to be selected by Content ID

### DIFF
--- a/src/code/FourRoads.TelligentCommunity.MetaData/Interfaces/IMetaDataLogic.cs
+++ b/src/code/FourRoads.TelligentCommunity.MetaData/Interfaces/IMetaDataLogic.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using FourRoads.TelligentCommunity.MetaData.Logic;
+using System;
 
 namespace FourRoads.TelligentCommunity.MetaData.Interfaces
 {
@@ -13,5 +14,6 @@ namespace FourRoads.TelligentCommunity.MetaData.Interfaces
         bool CanEdit { get; }
         string FormatMetaString(string rawFieldValue, string seperator, IDictionary namedParameters);
         string GetBestImageUrlForCurrent();
+        string GetBestImageUrlForContent(Guid contentId, Guid contentTypeId);
     }
 }

--- a/src/code/FourRoads.TelligentCommunity.MetaData/ScriptedFragmentss/MetaDataScriptedFragment.cs
+++ b/src/code/FourRoads.TelligentCommunity.MetaData/ScriptedFragmentss/MetaDataScriptedFragment.cs
@@ -49,6 +49,11 @@ namespace FourRoads.TelligentCommunity.MetaData.ScriptedFragmentss
             return MetaDataLogic.GetBestImageUrlForCurrent();
         }
 
+        public string GetBestImageUrlForContent(Guid contentId, Guid contentTypeId)
+        {
+            return MetaDataLogic.GetBestImageUrlForContent(contentId, contentTypeId);
+        }
+
         public string SaveMetaDataConfiguration(string title, string description, string keywords, bool ignore , IDictionary extendedTags )
         {
             try


### PR DESCRIPTION
The Meta Data plugin allows an image to be found based on the current
content item.

This functionality can also be useful to get an image to use when
displaying content elsewhere on the site.

Update to allow a ContentId and ContentTypeId to be specified.

Usage:
`$frcommon_v1_metaData.GetBestImageUrlForContent($blogPost.ContentId, $blogPost.ContentTypeId)`
