### PR TITLE
Add Rest API for Meta Data Image

### DIFF
--- a/src/code/FourRoads.TelligentCommunity.MetaData/FourRoads.TelligentCommunity.MetaData.csproj
+++ b/src/code/FourRoads.TelligentCommunity.MetaData/FourRoads.TelligentCommunity.MetaData.csproj
@@ -87,6 +87,9 @@
     <Reference Include="Telligent.Evolution.Core">
       <HintPath>..\..\lib\Telligent\Telligent.Evolution.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Telligent.Evolution.Rest">
+      <HintPath>..\..\lib\Telligent\Telligent.Evolution.Rest.dll</HintPath>
+    </Reference>
     <Reference Include="Telligent.Evolution.ScriptedContentFragments">
       <HintPath>..\..\lib\Telligent\Telligent.Evolution.ScriptedContentFragments.dll</HintPath>
     </Reference>
@@ -108,6 +111,8 @@
     <Compile Include="Logic\MetaDataLogic.cs" />
     <Compile Include="Logic\MetaData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Rest\Entities\ShowMetaDataResponse.cs" />
+    <Compile Include="Rest\MetaDataRestEndpoints.cs" />
     <Compile Include="ScriptedFragmentss\AdministrationPanel.cs" />
     <Compile Include="ScriptedFragmentss\MetaDataScriptedFragment.cs" />
     <Compile Include="Security\PermissionRegistrar.cs" />

--- a/src/code/FourRoads.TelligentCommunity.MetaData/Rest/Entities/ShowMetaDataResponse.cs
+++ b/src/code/FourRoads.TelligentCommunity.MetaData/Rest/Entities/ShowMetaDataResponse.cs
@@ -1,0 +1,13 @@
+﻿using Telligent.Evolution.Rest.Infrastructure.Version2;
+
+namespace FourRoads.TelligentCommunity.MetaData.Rest.Entities
+{
+    public class ShowMetaDataImageResponse : DefaultRestResponse
+    {
+        public ShowMetaDataImageResponse()
+        {
+            Name = "meta-data-image";
+            Errors = new string[0];
+        }
+    }
+}

--- a/src/code/FourRoads.TelligentCommunity.MetaData/Rest/MetaDataRestEndpoints.cs
+++ b/src/code/FourRoads.TelligentCommunity.MetaData/Rest/MetaDataRestEndpoints.cs
@@ -1,0 +1,81 @@
+﻿using FourRoads.Common;
+using FourRoads.TelligentCommunity.MetaData.Interfaces;
+using FourRoads.TelligentCommunity.MetaData.Rest.Entities;
+using System;
+using Telligent.Evolution.Extensibility.Rest.Version2;
+
+namespace FourRoads.TelligentCommunity.MetaData.Rest
+{
+    public class MetaDataRestEndpoints : IRestEndpoints, IApplicationPlugin
+    {
+        private IMetaDataLogic _logic;
+
+        public MetaDataRestEndpoints()
+        {
+            _logic = Injector.Get<IMetaDataLogic>();
+        }
+
+        public string Description
+        {
+            get
+            {
+                return "Enables REST API support for Meta Data Information";
+            }
+        }
+
+        public string Name
+        {
+            get
+            {
+                return "Meta Data Rest API Endpoints";
+            }
+        }
+
+        public void Initialize()
+        {
+        }
+
+        public void Register(IRestEndpointController restRoutes)
+        {
+            restRoutes.Add(2, "content/meta-data/image/{contentTypeId}/{contentId}", new { resource = "meta-data", action = "show" }, null, HttpMethod.Get, ShowMetaDataImage);
+        }
+        
+        private IRestResponse ShowMetaDataImage(IRestRequest request)
+        {
+            var response = new ShowMetaDataImageResponse();
+
+            Guid contentTypeId = Guid.Empty;
+            Guid contentId = Guid.Empty;
+
+            if (!Guid.TryParse(request.PathParameters["contentTypeId"].ToString(), out contentTypeId))
+            {
+                response.Errors = new[] { "ContentTypeId must be valid" };
+                return response;
+            }
+
+            if (!Guid.TryParse(request.PathParameters["contentId"].ToString(), out contentId))
+            {
+                response.Errors = new[] { "ContentId must be valid" };
+                return response;
+            }
+
+            if (contentTypeId == Guid.Empty)
+            {
+                response.Errors = new[] { "ContentTypeId must be specified" };
+                return response;
+            }
+
+            if (contentId == Guid.Empty)
+            {
+                response.Errors = new[] { "ContentId must be specified" };
+                return response;
+            }
+
+            var imageUrl = _logic.GetBestImageUrlForContent(contentId, contentTypeId);
+
+            response.Data = string.IsNullOrWhiteSpace(imageUrl) ? string.Empty : imageUrl;
+
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
Add a REST API that allows the image selected by the Meta Data plugin based on ContentId and ContentTypeId.

Usage:

/api.ashx/v2/content/meta-data/image/{contentTypeId}/{contentId}.json (or .xml)

Returns the URL of the image found, or an empty string if no image found.

If ContentTypeId or ContentId is in an incorrect format an error response will be returned with the reason in the Errors collection.

Example Response:

```
{  
   "meta-data-image":"http://www.example.org/images/some-image.png",
   "Errors":[  

   ]
}
```
