### PR TITLE
Renaming Meta data image property

### DIFF
--- a/src/code/FourRoads.TelligentCommunity.MetaData/Rest/Entities/ShowMetaDataResponse.cs
+++ b/src/code/FourRoads.TelligentCommunity.MetaData/Rest/Entities/ShowMetaDataResponse.cs
@@ -6,7 +6,7 @@ namespace FourRoads.TelligentCommunity.MetaData.Rest.Entities
     {
         public ShowMetaDataImageResponse()
         {
-            Name = "meta-data-image";
+            Name = "MetaDataImage";
             Errors = new string[0];
         }
     }


### PR DESCRIPTION
Renaming the Meta Data Image property that is returned by the API. Hyphens in the name was a stupid idea that made it hard to use the response with JSON serializers.

This is a breaking change, but believe we are the only project currently using this API.
