### PR TITLE
Allow links to be forced to lowercase

### DIFF
--- a/src/code/FourRoads.TelligentCommunity.Links/LinkModifyerPlugin.cs
+++ b/src/code/FourRoads.TelligentCommunity.Links/LinkModifyerPlugin.cs
@@ -30,12 +30,13 @@ namespace FourRoads.TelligentCommunity.Links
 
         private void EventsOnRender(HtmlRenderEventArgs htmlRenderEventArgs)
         {
-            htmlRenderEventArgs.RenderedHtml = new LinkModifyer(_ensureLocalLinksMatchUriScheme, _makeExternalUrlsTragetBlank).UpdateHtml(htmlRenderEventArgs.RenderedHtml);
+            htmlRenderEventArgs.RenderedHtml = new LinkModifyer(_ensureLocalLinksMatchUriScheme, _makeExternalUrlsTragetBlank, _ensureLocalLinksLowercase).UpdateHtml(htmlRenderEventArgs.RenderedHtml);
         }
 
     
         private bool _ensureLocalLinksMatchUriScheme = true;
         private bool _makeExternalUrlsTragetBlank = true;
+        private bool _ensureLocalLinksLowercase = false;
 
         public void Update(IPluginConfiguration configuration)
         {
@@ -43,6 +44,7 @@ namespace FourRoads.TelligentCommunity.Links
 
             _ensureLocalLinksMatchUriScheme = _configuration.GetBool("ensureLocalLinksMatchUriScheme");
             _makeExternalUrlsTragetBlank = _configuration.GetBool("makeExternalUrlsTragetBlank");
+            _ensureLocalLinksLowercase = _configuration.GetBool("ensureLocalLinksLowercase");
         }
 
         private IPluginConfiguration Configuration
@@ -65,6 +67,10 @@ namespace FourRoads.TelligentCommunity.Links
                 Property externalNewWindow = new Property("makeExternalUrlsTragetBlank", "Target Blank", PropertyType.Bool, 1, "true") { DescriptionText = "This will check each offsite anchor link and if enabled make every link traget '_blank'" };
 
                 optionsGroup.Properties.Add(externalNewWindow);
+
+                Property lowercaseUrls = new Property("ensureLocalLinksLowercase", "Lowercase", PropertyType.Bool, 2, "false") { DescriptionText = "This will check each local link and make the link lowercase" };
+
+                optionsGroup.Properties.Add(lowercaseUrls);
 
                 return groupArray;
             }


### PR DESCRIPTION
Update the links plugin to allow all local links in content to be forced to lowercase.

Defaults to off (to ensure compatibility with current installations of the plugin).

Only updates local links (regardless of it being an absolute url (/whatever/), full url to the same domain (http://mycommunity.com/whatever/), or protocol relative URL (//mycommunity.com/whatever)).

Doesn't alter external links (links with a different host segment).

Doesn't alter Query string values or Anchors, these can be case sensitive so forcing them to lower case could break links.
